### PR TITLE
Used load_dotenv, bot reponds when mentioned

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,13 +1,15 @@
-import discord
+import discord, os
 from discord.ext import commands, tasks
 import asyncio
 import urllib.request
 import json
 
-from dotenv import dotenv_values
+from dotenv import load_dotenv
 
-config = dotenv_values(".env")
-client = commands.Bot(command_prefix=".")
+load_dotenv()
+token = os.getenv('token')
+
+client = commands.Bot(command_prefix=commands.when_mentioned_or("."))
 
 
 @client.event
@@ -226,4 +228,4 @@ async def motivational_quote(ctx,*tags):
     await ctx.send(embed=quote_embed)
 
 
-client.run(config["token"])
+client.run(token)


### PR DESCRIPTION
I have made some changes to the bot.py file, now the bot responds when mentioned, as well as when we use its prefix "." . Also I used "load_dotenv" instead of "dotenv_values", which in my opinion is easier to use rather than "dotenv_values". 
A screenshot of the bot -
![Screen shot](https://cdn.discordapp.com/attachments/884651464000147476/894920449232867358/unknown.png)

Also not to mention, when using "load_dotenv", your file should be named ".env" and not in ".env.sample"